### PR TITLE
added storefront template hint path in ConfigUpdate

### DIFF
--- a/Controller/Action/ConfigUpdate.php
+++ b/Controller/Action/ConfigUpdate.php
@@ -105,6 +105,7 @@ class ConfigUpdate extends \ADM\QuickDevBar\Controller\Index
                     $configValue = ($this->_qdbHelper->getConfig('dev/debug/template_hints', $configScope, $configScopeId)) ? 0 : 1;
 
                     $this->_resourceConfig->saveConfig('dev/debug/template_hints', $configValue, $configScope, $configScopeId);
+                    $this->_resourceConfig->saveConfig('dev/debug/template_hints_storefront', $configValue, $configScope, $configScopeId);
                     $this->_resourceConfig->saveConfig('dev/debug/template_hints_blocks', $configValue, $configScope, $configScopeId);
                     $output = "Hints set " . ($configValue ? 'On' : 'Off');
                     break;


### PR DESCRIPTION
On a clean magento 2.1 the frontend path hints config parameter seems to now be dev/debug/template_hints_storefront - updated ConfigUpdate.php accordingly.