### PR TITLE
add translations tab

### DIFF
--- a/Block/Tab/Content/Translation.php
+++ b/Block/Tab/Content/Translation.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace ADM\QuickDevBar\Block\Tab\Content;
+
+use ADM\QuickDevBar\Helper\Translate;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\View\Element\Template;
+
+class Translation extends \ADM\QuickDevBar\Block\Tab\Panel
+{
+    /**
+     * @var Translate
+     */
+    private $translate;
+
+    /**
+     * @param Template\Context $context
+     * @param Translate $translate
+     * @param array $data
+     */
+    public function __construct(
+        Template\Context $context,
+        Translate $translate,
+        array $data = []
+    ) {
+        parent::__construct($context, $data);
+        $this->translate = $translate;
+    }
+
+    /**
+     * @return array
+     * @throws LocalizedException
+     */
+    public function getTranslations()
+    {
+        return $this->translate->getTranslationsByType(strtolower($this->getTitle()));
+    }
+}

--- a/Helper/Translate.php
+++ b/Helper/Translate.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace ADM\QuickDevBar\Helper;
+
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\ScopeResolverInterface;
+use Magento\Framework\App\State;
+use Magento\Framework\Cache\FrontendInterface;
+use Magento\Framework\Exception\LocalizedException;
+use Magento\Framework\File\Csv;
+use Magento\Framework\Filesystem;
+use Magento\Framework\Filesystem\DirectoryList;
+use Magento\Framework\Locale\ResolverInterface;
+use Magento\Framework\Module\Dir\Reader;
+use Magento\Framework\Module\ModuleList;
+use Magento\Framework\Translate\ResourceInterface;
+use Magento\Framework\View\DesignInterface;
+use Magento\Framework\View\FileSystem as ViewFileSystem;
+use Magento\Framework\App\Language\Dictionary;
+
+class Translate extends \Magento\Framework\Translate
+{
+    /**
+     * Checks if we have loaded our translation data.
+     *
+     * @var bool
+     */
+    protected $_hasLoaded = false;
+
+    /**
+     * @var DirectoryList
+     */
+    private $directoryList;
+
+    /**
+     * @param DesignInterface $viewDesign
+     * @param FrontendInterface $cache
+     * @param ViewFileSystem $viewFileSystem
+     * @param ModuleList $moduleList
+     * @param Reader $modulesReader
+     * @param ScopeResolverInterface $scopeResolver
+     * @param ResourceInterface $translate
+     * @param ResolverInterface $locale
+     * @param State $appState
+     * @param Filesystem $filesystem
+     * @param RequestInterface $request
+     * @param Csv $csvParser
+     * @param Dictionary $packDictionary
+     * @param DirectoryList $directoryList
+     */
+    public function __construct(
+        DesignInterface $viewDesign,
+        FrontendInterface $cache,
+        ViewFileSystem $viewFileSystem,
+        ModuleList $moduleList,
+        Reader $modulesReader,
+        ScopeResolverInterface $scopeResolver,
+        ResourceInterface $translate,
+        ResolverInterface $locale,
+        State $appState,
+        Filesystem $filesystem,
+        RequestInterface $request,
+        Csv $csvParser,
+        Dictionary $packDictionary,
+        DirectoryList $directoryList
+    ) {
+        parent::__construct(
+            $viewDesign,
+            $cache,
+            $viewFileSystem,
+            $moduleList,
+            $modulesReader,
+            $scopeResolver,
+            $translate,
+            $locale,
+            $appState,
+            $filesystem,
+            $request,
+            $csvParser,
+            $packDictionary
+        );
+        $this->directoryList = $directoryList;
+    }
+
+    /**
+     * Gets relative file path for absolute path.
+     *
+     * @param string $absolutePath
+     * @return string
+     */
+    protected function _getRelativeFilePath($absolutePath)
+    {
+        return str_replace($this->directoryList->getRoot() . DIRECTORY_SEPARATOR, '', $absolutePath);
+    }
+
+    /**
+     * Load current theme translation
+     *
+     * @return $this
+     */
+    protected function _loadThemeTranslation()
+    {
+        $file = $this->_getThemeTranslationFile($this->getLocale());
+        if ($file) {
+            $relativePath = $this->_getRelativeFilePath($file);
+            foreach ($this->_getFileData($file) as $key => $value) {
+                if ($key === $value) {
+                    continue;
+                }
+                $this->_data['theme'][htmlspecialchars($key)] = [
+                    'file' => $relativePath,
+                    'translation' => htmlspecialchars($value)
+                ];
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Load translation dictionary from language packages.
+     *
+     * @todo    It's also possible to get the filename of the language pack here, but generally only a single
+     *          language pack will be installed for a given locale.
+     * @return $this
+     * @throws LocalizedException
+     */
+    protected function _loadPackTranslation()
+    {
+        $this->_data['pack'] = $this->packDictionary->getDictionary($this->getLocale());
+        return $this;
+    }
+
+    /**
+     * Loading current translation from DB
+     *
+     * @return $this
+     */
+    protected function _loadDbTranslation()
+    {
+        $this->_data['db'] = $this->_translateResource->getTranslationArray(null, $this->getLocale());
+        return $this;
+    }
+
+
+    /**
+     * Load data from module translation files by list of modules
+     *
+     * @param array $modules
+     * @return $this
+     */
+    protected function loadModuleTranslationByModulesList(array $modules)
+    {
+        foreach ($modules as $module) {
+            $moduleFilePath = $this->_getModuleTranslationFile($module, $this->getLocale());
+            $relativePath = $this->_getRelativeFilePath($moduleFilePath);
+            foreach ($this->_getFileData($moduleFilePath) as $key => $value) {
+                if ($key === $value) {
+                    continue;
+                }
+                $this->_data['module'][htmlspecialchars($key)] = [
+                    'file' => $relativePath,
+                    'translation' => htmlspecialchars($value)
+                ];
+            }
+        }
+        return $this;
+    }
+
+    /**
+     * Gets translation data by type.
+     *
+     * @param string $type
+     * @return array
+     * @throws LocalizedException
+     */
+    public function getTranslationsByType($type)
+    {
+        if ($this->_hasLoaded === false) {
+            $this->loadData(null, true);
+            $this->_hasLoaded = true;
+        }
+        return $this->_data[$type] ?? [];
+    }
+}

--- a/view/base/layout/quickdevbar.xml
+++ b/view/base/layout/quickdevbar.xml
@@ -136,7 +136,35 @@
                     <action method="setTitleImage">
                       <argument name="title" xsi:type="string">ADM_QuickDevBar::images/tools.png</argument>
                     </action>                                     
-                  </block>      
+                  </block>
+                  <block class="ADM\QuickDevBar\Block\Tab\Wrapper" name="qdb.tab.translation" as="qdb.tab.translation" template="tabs.phtml">
+                      <action method="setTitle">
+                          <argument name="title" xsi:type="string">Translations</argument>
+                      </action>
+                      <action method="setTitleImage">
+                          <argument name="title" xsi:type="string">ADM_QuickDevBar::images/translations.png</argument>
+                      </action>
+                      <block class="ADM\QuickDevBar\Block\Tab\Content\Translation" name="qdb.tab.translation.module" as="qdb.tab.translation.module" template="tab/translation/file.phtml">
+                          <action method="setTitle">
+                              <argument name="title" xsi:type="string">Module</argument>
+                          </action>
+                      </block>
+                      <block class="ADM\QuickDevBar\Block\Tab\Content\Translation" name="qdb.tab.translation.pack" as="qdb.tab.translation.pack" template="tab/translation/plain.phtml">
+                          <action method="setTitle">
+                              <argument name="title" xsi:type="string">Pack</argument>
+                          </action>
+                      </block>
+                      <block class="ADM\QuickDevBar\Block\Tab\Content\Translation" name="qdb.tab.translation.theme" as="qdb.tab.translation.theme" template="tab/translation/file.phtml">
+                          <action method="setTitle">
+                              <argument name="title" xsi:type="string">Theme</argument>
+                          </action>
+                      </block>
+                      <block class="ADM\QuickDevBar\Block\Tab\Content\Translation" name="qdb.tab.translation.db" as="qdb.tab.translation.db" template="tab/translation/plain.phtml">
+                          <action method="setTitle">
+                              <argument name="title" xsi:type="string">DB</argument>
+                          </action>
+                      </block>
+                  </block>
                   <block class="ADM\QuickDevBar\Block\Tab\Content\Help" name="qdb.tab.help" as="qdb.tab.help" template="tab/help.phtml">
                     <action method="setTitle">
                       <argument name="title" xsi:type="string">Help</argument>

--- a/view/base/templates/tab/translation/file.phtml
+++ b/view/base/templates/tab/translation/file.phtml
@@ -1,0 +1,23 @@
+<?php if($this->getTranslations()):?>
+    <table class="qdn_table striped filterable">
+        <thead>
+        <tr>
+            <th>File</th>
+            <th>Original</th>
+            <th>Translation</th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php
+        $i = 0;
+        foreach ($this->getTranslations() as $original => $translation): ?>
+            <tr>
+                <td><?php echo $translation['file']; ?></td>
+                <td><?php echo $original; ?></td>
+                <td><?php echo $translation['translation']; ?></td>
+            </tr>
+            <?php $i++; ?>
+        <?php endforeach ?>
+        </tbody>
+    </table>
+<?php endif;?>

--- a/view/base/templates/tab/translation/plain.phtml
+++ b/view/base/templates/tab/translation/plain.phtml
@@ -1,0 +1,21 @@
+<?php if($this->getTranslations()):?>
+    <table class="qdn_table striped filterable">
+        <thead>
+        <tr>
+            <th>Original</th>
+            <th>Translation</th>
+        </tr>
+        </thead>
+        <tbody>
+        <?php
+        $i = 0;
+        foreach ($this->getTranslations() as $original => $translation): ?>
+            <tr>
+                <td><?php echo $original; ?></td>
+                <td><?php echo $translation; ?></td>
+            </tr>
+            <?php $i++; ?>
+        <?php endforeach ?>
+        </tbody>
+    </table>
+<?php endif;?>


### PR DESCRIPTION
We added the following information about translations:
- Module translations
- Translation pack
- Theme translations
- DB translations

Where possible, we specify the filename that last loaded that specific
translation, so it's very easy to debug issues where you can't seem to
translate something.