### PR TITLE
Small bug fix for users using a proxy with Magento 2. 

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -104,10 +104,11 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         return $separator ? implode($separator ,$allowedIps) : $allowedIps;
     }
 
-
     public function getClientIp()
     {
-        return $this->_getRequest()->getClientIp();
+        /*FIX FOR PROXY USERS RETURNING TWO IP ADDRESSES e.g. 127.0.0.1 127.0.0.1*/
+//        return $this->_getRequest()->getClientIp();
+        return $this->_remoteAddress->getRemoteAddress();
     }
 
     public function isUserAgentAuthorized()


### PR DESCRIPTION
Modified Helper/Data.php by changing the value that's returned by getClientIp(). It's now updated to use the same call that Magento uses natively to check the IP address when enabling Template Path Hints. This uses the remote address to find the IP address instead of the HTTP_X_FORWARDED_FOR header. HTTP_X_FORWARDED_FOR can return multiple IP addresses for those using a proxy like varnish if the header value isn't explicitly set via the varnish config.

BEFORE CHANGE:
![before-change](https://user-images.githubusercontent.com/31102449/53272468-027a5f00-36b7-11e9-93b5-9c3ebfaabc89.png)

AFTER CHANGE:
![after-change](https://user-images.githubusercontent.com/31102449/53272477-0dcd8a80-36b7-11e9-87b4-c0f17614bdf4.png)

