### PR TITLE
[ISSUE-28]: PHP < 7.0 backward compatible

### DIFF
--- a/Helper/Translate.php
+++ b/Helper/Translate.php
@@ -179,6 +179,6 @@ class Translate extends \Magento\Framework\Translate
             $this->loadData(null, true);
             $this->_hasLoaded = true;
         }
-        return $this->_data[$type] ?? [];
+        return isset($this->_data[$type]) ? $this->_data[$type] : [];
     }
 }


### PR DESCRIPTION
### Description (*)

PHP < 7.0 backward compatible

### Fixed Issues (if relevant)
1. [vpietri/magento2-developer-quickdevbar/#28](https://github.com/vpietri/magento2-developer-quickdevbar/issues/28):  PHP 7.0 - Null coalescing operator

### Manual testing scenarios (*)

