### PR TITLE
Correct Array Map Bug

### DIFF
--- a/Block/Tab/Content/PhpInfo.php
+++ b/Block/Tab/Content/PhpInfo.php
@@ -31,7 +31,7 @@ class PhpInfo extends \ADM\QuickDevBar\Block\Tab\Panel
             return "<style type='text/css'>" . PHP_EOL .
                     join( PHP_EOL,
                             array_map(
-                                    $this->phpInfoCssLambda(),
+                                    array(&$this, "phpInfoCssLambda"),
                                     preg_split( '/\n/', trim($matches[1]))
                             )
                     ). PHP_EOL .


### PR DESCRIPTION
Pass the class method correctly to the array_map function