### PR TITLE
Fixed report from Content Security Policies module

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<csp_whitelist xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Csp:etc/csp_whitelist.xsd">
+    <policies>
+        <policy id="img-src">
+            <values>
+                <value id="githubusercontent_images" type="host">camo.githubusercontent.com</value>
+            </values>
+        </policy>
+    </policies>
+</csp_whitelist>


### PR DESCRIPTION
Steps to reproduce: install Magento 2.4.0, check console log: no errors.
Install QuickDevBar, check console, there is an error:

> (index):504 [Report Only] Refused to load the image 'https://camo.githubusercontent.com/365986a……622f726…' because it violates the following Content Security Policy directive: "img-src widgets.magentocommerce.com www.googleadservices.com www.google-analytics.com www.paypalobjects.com t.paypal.com www.paypal.com fpdbs.paypal.com fpdbs.sandbox.paypal.com *.vimeocdn.com s.ytimg.com d3sbl0c71oxeok.cloudfront.net dhkkzdfmpzvap.cloudfront.net d2bpzs5y44q6e0.cloudfront.net d37shgu97oizpd.cloudfront.net d1zlqll3enr74n.cloudfront.net d1jynp0fpwn93a.cloudfront.net d2cb3tokgpwh3v.cloudfront.net d1re8bfxx3pw6e.cloudfront.net d35u8xwkxs8vpe.cloudfront.net d13s9xffygp5o.cloudfront.net d388nbw0dwi1jm.cloudfront.net d11p2vtu3dppaw.cloudfront.net d3r89hiip86hka.cloudfront.net dc7snq0c8ipyk.cloudfront.net d5c7kvljggzso.cloudfront.net d2h8yg3ypfzua1.cloudfront.net d1b556x7apj5fb.cloudfront.net draz1ib3z71v2.cloudfront.net dr6hdp4s5yzfc.cloudfront.net d2bomicxw8p7ii.cloudfront.net d3aypcdgvjnnam.cloudfront.net d2a3iuf10348gy.cloudfront.net *.ssl-images-amazon.com *.ssl-images-amazon.co.uk *.ssl-images-amazon.co.jp *.ssl-images-amazon.jp *.ssl-images-amazon.it *.ssl-images-amazon.fr *.ssl-images-amazon.es *.media-amazon.com *.media-amazon.co.uk *.media-amazon.co.jp *.media-amazon.jp *.media-amazon.it *.media-amazon.fr *.media-amazon.es yotpo.com www.yotpo.com p.yotpo.com staticw2.yotpo.com w2.yotpo.com 'self' 'unsafe-inline'".


![image](https://user-images.githubusercontent.com/475660/90567233-87620e00-e1b2-11ea-8745-2145690d6704.png)

This error is fixed by adding a CSP white-list according to:
https://devdocs.magento.com/guides/v2.4/extension-dev-guide/security/content-security-policies.html

