### PR TITLE
issue 70: fixed error TypeError: count(): Argument #1 ($value) must b…

### DIFF
--- a/Block/Tab/Content/Collection.php
+++ b/Block/Tab/Content/Collection.php
@@ -25,7 +25,7 @@ class Collection extends \ADM\QuickDevBar\Block\Tab\Panel
     public function getTitleBadge()
     {
         $collections = $this->getCollections();
-        return count($collections);
+        return count($collections ?? []);
     }
 
 


### PR DESCRIPTION
…e of type Countable|array, null given