### PR TITLE
Add support for Magento 2.4.5-p9 and all of the versions which doesn't supports mixed types

### DIFF
--- a/Block/Tab/Content/Sql.php
+++ b/Block/Tab/Content/Sql.php
@@ -112,7 +112,7 @@ class Sql extends \ADM\QuickDevBar\Block\Tab\Panel
         return $this->getSqlProfiler()->getShowBacktrace();
     }
 
-    public function formatSqlTrace(mixed $bt)
+    public function formatSqlTrace($bt)
     {
         $traceFormated = [];
         foreach ($bt as $i=>$traceLine) {

--- a/Block/Tab/Panel.php
+++ b/Block/Tab/Panel.php
@@ -227,7 +227,7 @@ class Panel extends \Magento\Framework\View\Element\Template
         return $buffer;
     }
 
-    public function htmlFormatClass(mixed $class)
+    public function htmlFormatClass($class)
     {
         return $this->helper->getIDELinkForClass($class);
     }


### PR DESCRIPTION
Since there is a mixed type, when you use developer mode Magento doesn't generates Interceptors for  a block : 
![image](https://github.com/user-attachments/assets/d6934969-4853-4802-ad59-07d6462c62d8)

and you could see an error :
```
2 exception(s):
Exception #0 (Magento\Framework\Exception\LocalizedException): Invalid block type: ADM\QuickDevBar\Block\Tab\Wrapper
Exception #1 (ReflectionException): Class "ADM\QuickDevBar\Block\Tab\Wrapper\Interceptor" does not exist

Exception #0 (Magento\Framework\Exception\LocalizedException): Invalid block type: ADM\QuickDevBar\Block\Tab\Wrapper
<pre>#1 Magento\Framework\View\Layout\Generator\Block->createBlock() called at [vendor/magento/framework/View/Layout/Generator/Block.php:229]
#2 Magento\Framework\View\Layout\Generator\Block->generateBlock() called at [vendor/magento/framework/View/Layout/Generator/Block.php:134]
```

which requires extra setup:di:compile and only after that it works fine.
So, could you please accept this merge request and improve - supporting for other Magento versions?
