### PR TITLE
Fix the typo in the XML closing tag within the comment.

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -16,8 +16,6 @@
         <policy id="script-src">
             <values>
                 <!-- Use https://emn178.github.io/online-tools/sha256.html with UTF-8 and Bse64 -->
-
-                -->
                 <value id="qdb-toolbar" type="hash" algorithm="sha256">SgvvFr+EuIbNctHUihu7npbOfmUqDK4M7sA5gSEUN48=</value>
                 <value id="qdb-profiler" type="hash" algorithm="sha256">hnovV8f+WhZ9ebCoXRqdN5AB0kK8XLdG0m1A1iJwEnY=</value>
                 <value id="qdb-log" type="hash" algorithm="sha256">qNCjKiE6ytQPnSBywIMEXvzw+Ar3jDurzNb87EqtM5E=</value>


### PR DESCRIPTION
In the new version, a tag typo caused an error on the page, so it has been corrected.

```
he XML in file "/var/www/magento/vendor/vpietri/adm-quickdevbar/etc/csp_whitelist.xml" is invalid:
Element 'values': Character content other than whitespace is not allowed because the content type is 'element-only'.
Line: 17

Verify the XML and try again.
```

![image](https://github.com/user-attachments/assets/42f3c567-1fc8-44bb-b96f-87c4e20bb7a5)
