### PR TITLE
Update csp_whitelist.xml

### DIFF
--- a/etc/csp_whitelist.xml
+++ b/etc/csp_whitelist.xml
@@ -16,8 +16,6 @@
         <policy id="script-src">
             <values>
                 <!-- Use https://emn178.github.io/online-tools/sha256.html with UTF-8 and Bse64 -->
-
-                -->
                 <value id="qdb-toolbar" type="hash" algorithm="sha256">SgvvFr+EuIbNctHUihu7npbOfmUqDK4M7sA5gSEUN48=</value>
                 <value id="qdb-profiler" type="hash" algorithm="sha256">hnovV8f+WhZ9ebCoXRqdN5AB0kK8XLdG0m1A1iJwEnY=</value>
                 <value id="qdb-log" type="hash" algorithm="sha256">qNCjKiE6ytQPnSBywIMEXvzw+Ar3jDurzNb87EqtM5E=</value>


### PR DESCRIPTION
# Fix invalid XML in CSP whitelist configuration

## Issue
The Content Security Policy (CSP) whitelist XML contained invalid content that caused Magento's XML validation to fail with the error: `Element 'values': Character content other than whitespace is not allowed because the content type is 'element-only'`

## Changes
- Removed malformed HTML comment syntax
- Fixed documentation comment formatting to follow XML standards
- Ensured proper whitespace handling in `script-src` policy section
- Maintained all existing CSP hash values and functionality

## Testing
1. Magento setup:upgrade completes successfully
2. QuickDevBar continues to function as expected
3. CSP policies remain enforced with correct hash values

## Related Issue
Fixes XML validation error during module installation/upgrade process