### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ php bin/magento dev:quickdevbar:enable
 ```
 and activate full sql backtrace 
 ```
-php bin/magento dev:quickdevbar:enable --sql-qdb-profiler
+php bin/magento dev:quickdevbar:enable --sql-profiler
 ```
 
 Or via the standard configuration in the Advanced/Developer/Quick dev bar section.


### PR DESCRIPTION
```

[09:50:46]-[m2-web]--[/var/www/html]$ php bin/magento dev:quickdevbar:enable --help
Description:
  Activate quickdevbar

Usage:
  dev:quickdevbar:enable [options]

Options:
      --clear-front-cache  Clear front cache block_html & full_page
      --sql-profiler       Activate/deactivate SQL profiler
  -h, --help               Display help for the given command. When no command is given display help for the list command
  -q, --quiet              Do not output any message
  -V, --version            Display this application version
      --ansi|--no-ansi     Force (or disable --no-ansi) ANSI output
  -n, --no-interaction     Do not ask any interactive question
  -v|vv|vvv, --verbose     Increase the verbosity of messages: 1 for normal output, 2 for more verbose output and 3 for debug
[09:51:07]-[m2-web]--[/var/www/html]$ php bin/magento dev:quickdevbar:enable --sql-profiler
Toolbar enabled
SQL profiler is enabled in env.php
Cache cleared: config
```