### PR TITLE
fix: add plugin guards, production mode check, default-off

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -115,6 +115,10 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
 
     public function isToolbarAccessAllowed($testWithRestriction=false)
     {
+        if ($this->appState->getMode() === State::MODE_PRODUCTION) {
+            return false;
+        }
+
         $allow = false;
         $enable = $this->getQdbConfig('enable');
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -41,14 +41,20 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
      */
     private $appState;
     /**
-     * @var Session
+     * @var QdbSession
      */
     private $qdbSession;
 
     private array $ideList;
 
     /**
-     * @param \Magento\Framework\App\Config\ScopeConfigInterface $scopeConfig
+     * @param \Magento\Framework\App\Helper\Context $context
+     * @param \Magento\Framework\App\Cache\Frontend\Pool $cacheFrontendPool
+     * @param \Magento\Framework\Module\ModuleListInterface $moduleList
+     * @param \Magento\Framework\Filesystem $filesystem
+     * @param array $ideList
+     * @param State $appState
+     * @param QdbSession $qdbSession
      */
     public function __construct(
         \Magento\Framework\App\Helper\Context $context,

--- a/Plugin/Framework/App/Cache.php
+++ b/Plugin/Framework/App/Cache.php
@@ -28,6 +28,10 @@ class Cache
         return $this->isAllowed;
     }
 
+    /**
+     * @param CacheInterface $subject
+     * @param string $identifier
+     */
     public function beforeLoad(CacheInterface $subject, string $identifier)
     {
         if (!$this->isAllowed()) {
@@ -36,6 +40,13 @@ class Cache
         $this->cacheService->addCache('load', $identifier);
     }
 
+    /**
+     * @param CacheInterface $subject
+     * @param string $data
+     * @param string $identifier
+     * @param array $tags
+     * @param int|null $lifeTime
+     */
     public function beforeSave(
         CacheInterface $subject,
         string $data,
@@ -49,6 +60,10 @@ class Cache
         $this->cacheService->addCache('save', $identifier);
     }
 
+    /**
+     * @param CacheInterface $subject
+     * @param string $identifier
+     */
     public function beforeRemove(CacheInterface $subject, string $identifier)
     {
         if (!$this->isAllowed()) {

--- a/Plugin/Framework/App/Cache.php
+++ b/Plugin/Framework/App/Cache.php
@@ -1,38 +1,41 @@
 <?php
+
 namespace ADM\QuickDevBar\Plugin\Framework\App;
 
+use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\App\Cache as CacheService;
 use Magento\Framework\App\CacheInterface;
 
 class Cache
 {
-    /**
-     * @var \ADM\QuickDevBar\Service\App\Cache
-     */
-    private $cacheService;
+    private CacheService $cacheService;
+    private QdbHelper $qdbHelper;
+    private ?bool $isAllowed = null;
 
-    public function __construct(\ADM\QuickDevBar\Service\App\Cache $cacheService)
-    {
+    public function __construct(
+        CacheService $cacheService,
+        QdbHelper $qdbHelper
+    ) {
         $this->cacheService = $cacheService;
+        $this->qdbHelper = $qdbHelper;
     }
 
+    private function isAllowed(): bool
+    {
+        if ($this->isAllowed === null) {
+            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
+        }
+        return $this->isAllowed;
+    }
 
-    /**
-     * @param CacheInterface $subject
-     * @param string $identifier
-     */
     public function beforeLoad(CacheInterface $subject, string $identifier)
     {
+        if (!$this->isAllowed()) {
+            return;
+        }
         $this->cacheService->addCache('load', $identifier);
     }
 
-    /**
-     * @param CacheInterface $subject
-     * @param string $data
-     * @param string $identifier
-     * @param array $tags
-     * @param $lifeTime
-     * @return void
-     */
     public function beforeSave(
         CacheInterface $subject,
         string $data,
@@ -40,18 +43,17 @@ class Cache
         array $tags = [],
         $lifeTime = null
     ) {
-
+        if (!$this->isAllowed()) {
+            return;
+        }
         $this->cacheService->addCache('save', $identifier);
     }
 
-
-    /**
-     * @param CacheInterface $subject
-     * @param string $identifier
-     * @return void
-     */
     public function beforeRemove(CacheInterface $subject, string $identifier)
     {
+        if (!$this->isAllowed()) {
+            return;
+        }
         $this->cacheService->addCache('remove', $identifier);
     }
 }

--- a/Plugin/Framework/App/Cache.php
+++ b/Plugin/Framework/App/Cache.php
@@ -2,30 +2,21 @@
 
 namespace ADM\QuickDevBar\Plugin\Framework\App;
 
-use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\AccessChecker;
 use ADM\QuickDevBar\Service\App\Cache as CacheService;
 use Magento\Framework\App\CacheInterface;
 
 class Cache
 {
     private CacheService $cacheService;
-    private QdbHelper $qdbHelper;
-    private ?bool $isAllowed = null;
+    private AccessChecker $accessChecker;
 
     public function __construct(
         CacheService $cacheService,
-        QdbHelper $qdbHelper
+        AccessChecker $accessChecker
     ) {
         $this->cacheService = $cacheService;
-        $this->qdbHelper = $qdbHelper;
-    }
-
-    private function isAllowed(): bool
-    {
-        if ($this->isAllowed === null) {
-            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
-        }
-        return $this->isAllowed;
+        $this->accessChecker = $accessChecker;
     }
 
     /**
@@ -34,7 +25,7 @@ class Cache
      */
     public function beforeLoad(CacheInterface $subject, string $identifier)
     {
-        if (!$this->isAllowed()) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         $this->cacheService->addCache('load', $identifier);
@@ -54,7 +45,7 @@ class Cache
         array $tags = [],
         $lifeTime = null
     ) {
-        if (!$this->isAllowed()) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         $this->cacheService->addCache('save', $identifier);
@@ -66,7 +57,7 @@ class Cache
      */
     public function beforeRemove(CacheInterface $subject, string $identifier)
     {
-        if (!$this->isAllowed()) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         $this->cacheService->addCache('remove', $identifier);

--- a/Plugin/Framework/App/FrontController.php
+++ b/Plugin/Framework/App/FrontController.php
@@ -4,6 +4,7 @@ namespace ADM\QuickDevBar\Plugin\Framework\App;
 
 use ADM\QuickDevBar\Helper\Data;
 use ADM\QuickDevBar\Helper\Register;
+use ADM\QuickDevBar\Service\AccessChecker;
 use ADM\QuickDevBar\Service\Dumper;
 use Magento\Framework\App\RequestInterface;
 
@@ -17,22 +18,27 @@ class FrontController
 
     private Register $register;
 
+    private AccessChecker $accessChecker;
+
     /**
      * @param RequestInterface $request
      * @param Data $qdbHelper
      * @param Register $register
      * @param Dumper $dumper
+     * @param AccessChecker $accessChecker
      */
     public function __construct(RequestInterface $request,
                                 Data $qdbHelper,
                                 Register $register,
-                                Dumper $dumper
+                                Dumper $dumper,
+                                AccessChecker $accessChecker
     )
     {
         $this->request = $request;
         $this->qdbHelper = $qdbHelper;
         $this->register = $register;
         $this->dumper = $dumper;
+        $this->accessChecker = $accessChecker;
     }
 
     /**
@@ -47,7 +53,7 @@ class FrontController
     {
 
 
-        if(!$this->qdbHelper->isToolbarAccessAllowed()) {
+        if(!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
 

--- a/Plugin/Framework/App/UpdateCookies.php
+++ b/Plugin/Framework/App/UpdateCookies.php
@@ -3,7 +3,7 @@
 namespace ADM\QuickDevBar\Plugin\Framework\App;
 
 use ADM\QuickDevBar\Helper\Cookie;
-use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\AccessChecker;
 use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 
@@ -11,25 +11,21 @@ class UpdateCookies
 {
     private CookieManagerInterface $cookieManager;
     private CookieMetadataFactory $cookieMetadataFactory;
-    private QdbHelper $qdbHelper;
-    private ?bool $isAllowed = null;
+    private AccessChecker $accessChecker;
 
     public function __construct(
         CookieManagerInterface $cookieManager,
         CookieMetadataFactory $cookieMetadataFactory,
-        QdbHelper $qdbHelper
+        AccessChecker $accessChecker
     ) {
         $this->cookieManager = $cookieManager;
         $this->cookieMetadataFactory = $cookieMetadataFactory;
-        $this->qdbHelper = $qdbHelper;
+        $this->accessChecker = $accessChecker;
     }
 
     public function beforeDispatch(): void
     {
-        if ($this->isAllowed === null) {
-            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
-        }
-        if (!$this->isAllowed) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
 

--- a/Plugin/Framework/App/UpdateCookies.php
+++ b/Plugin/Framework/App/UpdateCookies.php
@@ -3,58 +3,39 @@
 namespace ADM\QuickDevBar\Plugin\Framework\App;
 
 use ADM\QuickDevBar\Helper\Cookie;
-use Magento\Framework\App\PageCache\FormKey as CacheFormKey;
-use Magento\Framework\Data\Form\FormKey;
-use Magento\Framework\Escaper;
-use Magento\Framework\Session\Config\ConfigInterface;
+use ADM\QuickDevBar\Helper\Data as QdbHelper;
 use Magento\Framework\Stdlib\Cookie\CookieMetadataFactory;
 use Magento\Framework\Stdlib\CookieManagerInterface;
 
 class UpdateCookies
 {
     private CookieManagerInterface $cookieManager;
-
     private CookieMetadataFactory $cookieMetadataFactory;
+    private QdbHelper $qdbHelper;
+    private ?bool $isAllowed = null;
 
-    /**
-     * @param CacheFormKey $cacheFormKey
-     * @param Escaper $escaper
-     * @param FormKey $formKey
-     * @param CookieMetadataFactory $cookieMetadataFactory
-     * @param ConfigInterface $sessionConfig
-     */
     public function __construct(
         CookieManagerInterface $cookieManager,
-        CookieMetadataFactory $cookieMetadataFactory
+        CookieMetadataFactory $cookieMetadataFactory,
+        QdbHelper $qdbHelper
     ) {
-
         $this->cookieManager = $cookieManager;
         $this->cookieMetadataFactory = $cookieMetadataFactory;
+        $this->qdbHelper = $qdbHelper;
     }
 
-    /**
-     * Set form key from the cookie.
-     *
-     * @return void
-     * @SuppressWarnings(PHPMD.UnusedFormalParameter)
-     */
     public function beforeDispatch(): void
     {
+        if ($this->isAllowed === null) {
+            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
+        }
+        if (!$this->isAllowed) {
+            return;
+        }
 
         $cookieValue = $this->cookieManager->getCookie(Cookie::COOKIE_NAME_PROFILER_ENABLED);
         if ($cookieValue) {
             //TODO: Update cookie lifetime
-
-//            $metadata = $this->cookieMetadataFactory
-//                ->createPublicCookieMetadata()
-//                ->setDuration(Cookie::COOKIE_DURATION);
-//
-//            $this->cookieManager->setPublicCookie(
-//                DbAdapter::COOKIE_NAME_PROFILER_ENABLED,
-//                $cookieValue,
-//                $metadata
-//            );
         }
     }
-
 }

--- a/Plugin/Framework/Event/Invoker.php
+++ b/Plugin/Framework/Event/Invoker.php
@@ -2,27 +2,35 @@
 
 namespace ADM\QuickDevBar\Plugin\Framework\Event;
 
+use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\Observer as ServiceObserver;
 use Magento\Framework\Event\Observer;
 
 class Invoker
 {
-    /**
-     * @var \ADM\QuickDevBar\Service\Observer
-     */
-    private $serviceObserver;
+    private ServiceObserver $serviceObserver;
+    private QdbHelper $qdbHelper;
+    private ?bool $isAllowed = null;
 
-
-    /**
-     * @param \ADM\QuickDevBar\Helper\Data $qdbHelper
-     */
     public function __construct(
-        \ADM\QuickDevBar\Service\Observer $serviceObserver
+        ServiceObserver $serviceObserver,
+        QdbHelper $qdbHelper
     ) {
         $this->serviceObserver = $serviceObserver;
+        $this->qdbHelper = $qdbHelper;
     }
 
-    public function beforeDispatch(\Magento\Framework\Event\InvokerInterface $class, array $configuration, Observer $observer)
-    {
+    public function beforeDispatch(
+        \Magento\Framework\Event\InvokerInterface $class,
+        array $configuration,
+        Observer $observer
+    ) {
+        if ($this->isAllowed === null) {
+            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
+        }
+        if (!$this->isAllowed) {
+            return;
+        }
         if (isset($configuration['disabled']) && true === $configuration['disabled']) {
             return;
         }

--- a/Plugin/Framework/Event/Invoker.php
+++ b/Plugin/Framework/Event/Invoker.php
@@ -20,6 +20,13 @@ class Invoker
         $this->qdbHelper = $qdbHelper;
     }
 
+    /**
+     * Record observer invocations for the dev bar profiler.
+     *
+     * @param \Magento\Framework\Event\InvokerInterface $class
+     * @param array $configuration
+     * @param Observer $observer
+     */
     public function beforeDispatch(
         \Magento\Framework\Event\InvokerInterface $class,
         array $configuration,

--- a/Plugin/Framework/Event/Invoker.php
+++ b/Plugin/Framework/Event/Invoker.php
@@ -2,22 +2,21 @@
 
 namespace ADM\QuickDevBar\Plugin\Framework\Event;
 
-use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\AccessChecker;
 use ADM\QuickDevBar\Service\Observer as ServiceObserver;
 use Magento\Framework\Event\Observer;
 
 class Invoker
 {
     private ServiceObserver $serviceObserver;
-    private QdbHelper $qdbHelper;
-    private ?bool $isAllowed = null;
+    private AccessChecker $accessChecker;
 
     public function __construct(
         ServiceObserver $serviceObserver,
-        QdbHelper $qdbHelper
+        AccessChecker $accessChecker
     ) {
         $this->serviceObserver = $serviceObserver;
-        $this->qdbHelper = $qdbHelper;
+        $this->accessChecker = $accessChecker;
     }
 
     /**
@@ -32,10 +31,7 @@ class Invoker
         array $configuration,
         Observer $observer
     ) {
-        if ($this->isAllowed === null) {
-            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
-        }
-        if (!$this->isAllowed) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         if (isset($configuration['disabled']) && true === $configuration['disabled']) {

--- a/Plugin/Framework/Event/Manager.php
+++ b/Plugin/Framework/Event/Manager.php
@@ -2,21 +2,20 @@
 
 namespace ADM\QuickDevBar\Plugin\Framework\Event;
 
-use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\AccessChecker;
 use ADM\QuickDevBar\Service\Event\Manager as ServiceManager;
 
 class Manager
 {
     private ServiceManager $serviceManager;
-    private QdbHelper $qdbHelper;
-    private ?bool $isAllowed = null;
+    private AccessChecker $accessChecker;
 
     public function __construct(
         ServiceManager $serviceManager,
-        QdbHelper $qdbHelper
+        AccessChecker $accessChecker
     ) {
         $this->serviceManager = $serviceManager;
-        $this->qdbHelper = $qdbHelper;
+        $this->accessChecker = $accessChecker;
     }
 
     /**
@@ -28,10 +27,7 @@ class Manager
      */
     public function beforeDispatch($interceptor, $eventName, $data = [])
     {
-        if ($this->isAllowed === null) {
-            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
-        }
-        if (!$this->isAllowed) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         $this->serviceManager->addEvent($eventName, $data);

--- a/Plugin/Framework/Event/Manager.php
+++ b/Plugin/Framework/Event/Manager.php
@@ -19,6 +19,13 @@ class Manager
         $this->qdbHelper = $qdbHelper;
     }
 
+    /**
+     * Record dispatched events for the dev bar profiler.
+     *
+     * @param \Magento\Framework\Event\ManagerInterface $interceptor
+     * @param string $eventName
+     * @param array $data
+     */
     public function beforeDispatch($interceptor, $eventName, $data = [])
     {
         if ($this->isAllowed === null) {

--- a/Plugin/Framework/Event/Manager.php
+++ b/Plugin/Framework/Event/Manager.php
@@ -2,34 +2,31 @@
 
 namespace ADM\QuickDevBar\Plugin\Framework\Event;
 
+use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\Event\Manager as ServiceManager;
+
 class Manager
 {
-    /**
-     * @var \ADM\QuickDevBar\Service\Manager
-     */
-    private $serviceManager;
+    private ServiceManager $serviceManager;
+    private QdbHelper $qdbHelper;
+    private ?bool $isAllowed = null;
 
-    /**
-     * @param \ADM\QuickDevBar\Helper\Register $qdbHelperRegister
-     */
     public function __construct(
-        \ADM\QuickDevBar\Service\Event\Manager $serviceManager
+        ServiceManager $serviceManager,
+        QdbHelper $qdbHelper
     ) {
         $this->serviceManager = $serviceManager;
+        $this->qdbHelper = $qdbHelper;
     }
 
-    /**
-     * Before dispatch event
-     *
-     * Calls all observer callbacks registered for this event
-     * and multiple observers matching event name pattern
-     *
-     * @param \Magento\Framework\Event\Manager $interceptor
-     * @param string $eventName
-     * @param array $data
-     */
     public function beforeDispatch($interceptor, $eventName, $data = [])
     {
+        if ($this->isAllowed === null) {
+            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
+        }
+        if (!$this->isAllowed) {
+            return;
+        }
         $this->serviceManager->addEvent($eventName, $data);
     }
 }

--- a/Plugin/PageCache/FrontController/BuiltinPlugin.php
+++ b/Plugin/PageCache/FrontController/BuiltinPlugin.php
@@ -28,6 +28,10 @@ class BuiltinPlugin
         return $this->isAllowed;
     }
 
+    /**
+     * @param PageCache $subject
+     * @param string $identifier
+     */
     public function beforeLoad(PageCache $subject, string $identifier)
     {
         if (!$this->isAllowed()) {
@@ -36,6 +40,13 @@ class BuiltinPlugin
         $this->cacheService->addCache('load', $identifier);
     }
 
+    /**
+     * @param PageCache $subject
+     * @param string $data
+     * @param string $identifier
+     * @param array $tags
+     * @param int|null $lifeTime
+     */
     public function beforeSave(
         PageCache $subject,
         string $data,
@@ -49,6 +60,10 @@ class BuiltinPlugin
         $this->cacheService->addCache('save', $identifier);
     }
 
+    /**
+     * @param PageCache $subject
+     * @param string $identifier
+     */
     public function beforeRemove(PageCache $subject, string $identifier)
     {
         if (!$this->isAllowed()) {

--- a/Plugin/PageCache/FrontController/BuiltinPlugin.php
+++ b/Plugin/PageCache/FrontController/BuiltinPlugin.php
@@ -2,30 +2,21 @@
 
 namespace ADM\QuickDevBar\Plugin\PageCache\FrontController;
 
-use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\AccessChecker;
 use ADM\QuickDevBar\Service\App\Cache as CacheService;
 use Magento\PageCache\Model\Cache\Type as PageCache;
 
 class BuiltinPlugin
 {
     private CacheService $cacheService;
-    private QdbHelper $qdbHelper;
-    private ?bool $isAllowed = null;
+    private AccessChecker $accessChecker;
 
     public function __construct(
         CacheService $cacheService,
-        QdbHelper $qdbHelper
+        AccessChecker $accessChecker
     ) {
         $this->cacheService = $cacheService;
-        $this->qdbHelper = $qdbHelper;
-    }
-
-    private function isAllowed(): bool
-    {
-        if ($this->isAllowed === null) {
-            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
-        }
-        return $this->isAllowed;
+        $this->accessChecker = $accessChecker;
     }
 
     /**
@@ -34,7 +25,7 @@ class BuiltinPlugin
      */
     public function beforeLoad(PageCache $subject, string $identifier)
     {
-        if (!$this->isAllowed()) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         $this->cacheService->addCache('load', $identifier);
@@ -54,7 +45,7 @@ class BuiltinPlugin
         array $tags = [],
         $lifeTime = null
     ) {
-        if (!$this->isAllowed()) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         $this->cacheService->addCache('save', $identifier);
@@ -66,7 +57,7 @@ class BuiltinPlugin
      */
     public function beforeRemove(PageCache $subject, string $identifier)
     {
-        if (!$this->isAllowed()) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         $this->cacheService->addCache('remove', $identifier);

--- a/Plugin/PageCache/FrontController/BuiltinPlugin.php
+++ b/Plugin/PageCache/FrontController/BuiltinPlugin.php
@@ -1,65 +1,59 @@
 <?php
 
-
 namespace ADM\QuickDevBar\Plugin\PageCache\FrontController;
 
-
+use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\App\Cache as CacheService;
 use Magento\PageCache\Model\Cache\Type as PageCache;
-use Magento\Framework\App\RequestInterface;
-use Magento\Framework\App\Response\Http as ResponseHttp;
-use Magento\Framework\App\ResponseInterface;
 
 class BuiltinPlugin
 {
-    /**
-     * @var \ADM\QuickDevBar\Service\App\Cache
-     */
-    private $cacheService;
+    private CacheService $cacheService;
+    private QdbHelper $qdbHelper;
+    private ?bool $isAllowed = null;
 
-    /**
-     * @param \ADM\QuickDevBar\Service\App\Cache $cacheService
-     */
-    public function __construct(\ADM\QuickDevBar\Service\App\Cache $cacheService)
-    {
+    public function __construct(
+        CacheService $cacheService,
+        QdbHelper $qdbHelper
+    ) {
         $this->cacheService = $cacheService;
+        $this->qdbHelper = $qdbHelper;
     }
 
-    /**
-     * @param PageCache $subject
-     * @param string $identifier
-     */
+    private function isAllowed(): bool
+    {
+        if ($this->isAllowed === null) {
+            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
+        }
+        return $this->isAllowed;
+    }
+
     public function beforeLoad(PageCache $subject, string $identifier)
     {
+        if (!$this->isAllowed()) {
+            return;
+        }
         $this->cacheService->addCache('load', $identifier);
     }
 
-    /**
-     * @param PageCache $subject
-     * @param string $data
-     * @param string $identifier
-     * @param array $tags
-     * @param $lifeTime
-     * @return void
-     */
     public function beforeSave(
         PageCache $subject,
         string $data,
         string $identifier,
         array $tags = [],
-                       $lifeTime = null
+        $lifeTime = null
     ) {
-
+        if (!$this->isAllowed()) {
+            return;
+        }
         $this->cacheService->addCache('save', $identifier);
     }
 
-
-    /**
-     * @param PageCache $subject
-     * @param string $identifier
-     * @return void
-     */
     public function beforeRemove(PageCache $subject, string $identifier)
     {
+        if (!$this->isAllowed()) {
+            return;
+        }
         $this->cacheService->addCache('remove', $identifier);
     }
 }

--- a/Plugin/Search/SearchClient.php
+++ b/Plugin/Search/SearchClient.php
@@ -2,12 +2,26 @@
 
 namespace ADM\QuickDevBar\Plugin\Search;
 
+use ADM\QuickDevBar\Helper\Data as QdbHelper;
+
 class SearchClient
 {
+    private QdbHelper $qdbHelper;
+    private ?bool $isAllowed = null;
+
+    public function __construct(QdbHelper $qdbHelper)
+    {
+        $this->qdbHelper = $qdbHelper;
+    }
+
     public function beforeQuery(\Magento\OpenSearch\Model\SearchClient $subject, array $query)
     {
-        dump($query);
-
+        if ($this->isAllowed === null) {
+            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
+        }
+        if (!$this->isAllowed) {
+            return;
+        }
         return [$query];
     }
 }

--- a/Plugin/Search/SearchClient.php
+++ b/Plugin/Search/SearchClient.php
@@ -2,24 +2,20 @@
 
 namespace ADM\QuickDevBar\Plugin\Search;
 
-use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\AccessChecker;
 
 class SearchClient
 {
-    private QdbHelper $qdbHelper;
-    private ?bool $isAllowed = null;
+    private AccessChecker $accessChecker;
 
-    public function __construct(QdbHelper $qdbHelper)
+    public function __construct(AccessChecker $accessChecker)
     {
-        $this->qdbHelper = $qdbHelper;
+        $this->accessChecker = $accessChecker;
     }
 
     public function beforeQuery(\Magento\OpenSearch\Model\SearchClient $subject, array $query)
     {
-        if ($this->isAllowed === null) {
-            $this->isAllowed = $this->qdbHelper->isToolbarAccessAllowed();
-        }
-        if (!$this->isAllowed) {
+        if (!$this->accessChecker->isToolbarAccessAllowed()) {
             return;
         }
         return [$query];

--- a/Service/AccessChecker.php
+++ b/Service/AccessChecker.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace ADM\QuickDevBar\Service;
+
+use Magento\Framework\App\Config\ScopeConfigInterface;
+use Magento\Framework\App\State;
+use Magento\Framework\HTTP\Header as HttpHeader;
+use Magento\Framework\HTTP\PhpEnvironment\RemoteAddress;
+
+class AccessChecker
+{
+    private State $appState;
+    private ScopeConfigInterface $scopeConfig;
+    private RemoteAddress $remoteAddress;
+    private HttpHeader $httpHeader;
+
+    private ?bool $isAllowed = null;
+    private static bool $isResolving = false;
+
+    public function __construct(
+        State $appState,
+        ScopeConfigInterface $scopeConfig,
+        RemoteAddress $remoteAddress,
+        HttpHeader $httpHeader
+    ) {
+        $this->appState = $appState;
+        $this->scopeConfig = $scopeConfig;
+        $this->remoteAddress = $remoteAddress;
+        $this->httpHeader = $httpHeader;
+    }
+
+    public function isToolbarAccessAllowed(bool $testWithRestriction = false): bool
+    {
+        // Re-entrancy guard: this method reads config which may trigger
+        // cache/DB/event operations that loop back through our plugins.
+        // During bootstrap, deny access rather than recurse.
+        if (self::$isResolving) {
+            return false;
+        }
+
+        if ($this->isAllowed !== null && !$testWithRestriction) {
+            return $this->isAllowed;
+        }
+
+        self::$isResolving = true;
+        try {
+            $result = $this->resolve($testWithRestriction);
+        } finally {
+            self::$isResolving = false;
+        }
+
+        if (!$testWithRestriction) {
+            $this->isAllowed = $result;
+        }
+
+        return $result;
+    }
+
+    private function resolve(bool $testWithRestriction): bool
+    {
+        if ($this->appState->getMode() === State::MODE_PRODUCTION) {
+            return false;
+        }
+
+        $enable = $this->getQdbConfig('enable');
+
+        if (!$enable && !$testWithRestriction) {
+            return false;
+        }
+
+        if ($enable > 1 || $testWithRestriction) {
+            return $this->isIpAuthorized() || $this->isUserAgentAuthorized();
+        }
+
+        return true;
+    }
+
+    private function isIpAuthorized(): bool
+    {
+        return in_array($this->remoteAddress->getRemoteAddress(), $this->getAllowedIps(), true);
+    }
+
+    private function getAllowedIps(): array
+    {
+        $allowedIps = $this->getQdbConfig('allow_ips');
+        if ($allowedIps) {
+            $allowedIps = preg_split('#\s*,\s*#', $allowedIps, -1, PREG_SPLIT_NO_EMPTY);
+        } else {
+            $allowedIps = [];
+        }
+
+        return array_merge(['127.0.0.1', '::1'], $allowedIps);
+    }
+
+    private function isUserAgentAuthorized(): bool
+    {
+        $toolbarHeader = $this->getQdbConfig('toolbar_header');
+
+        return !empty($toolbarHeader)
+            && preg_match('/' . preg_quote($toolbarHeader, '/') . '/', $this->httpHeader->getHttpUserAgent(true));
+    }
+
+    private function getQdbConfig(string $key): mixed
+    {
+        return $this->scopeConfig->getValue('dev/quickdevbar/' . $key);
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -7,6 +7,7 @@
       "AFL-3.0"
     ],
     "version": "0.3.4",
+    "keywords": ["dev", "debug", "developer", "toolbar", "profiler"],
     "require": {
       "magento/magento-composer-installer": "*"
     },

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -3,7 +3,7 @@
     <default>
         <dev>
             <quickdevbar>
-                <enable>2</enable>
+                <enable>0</enable>
                 <area>global</area>
                 <appearance>memorize</appearance>
                 <handle_vardumper>1</handle_vardumper>


### PR DESCRIPTION
## Summary

- Add `isToolbarAccessAllowed()` guard to all 6 unguarded plugins (Event Manager, Event Invoker, App Cache, PageCache BuiltinPlugin, UpdateCookies, SearchClient)
- Cache guard result per-request (`?bool $isAllowed`) to avoid repeated config lookups — hundreds of plugin calls per request reduced to a single check
- Block toolbar activation entirely in production mode (early return in `isToolbarAccessAllowed()`)
- Change default `enable` from `2` (IP-restricted) to `0` (disabled) — toolbar must be explicitly enabled
- Remove stray `dump()` call in SearchClient plugin (finding C1)
- Add dev/debug keywords to `composer.json`

## Security Findings Addressed

| ID | Finding |
|---|---|
| C1 | `dump()` in SearchClient leaks query data |
| H3 | Plugins run unconditionally — data collection even when toolbar disabled |
| H4 | No production mode guard — toolbar activatable in production |
| M5 | Default-on config (`enable=2`) — toolbar active on fresh install |

## Test Plan

- [ ] Fresh install: verify toolbar does not appear (default-off)
- [ ] Enable toolbar in developer mode: verify all plugin data collection works
- [ ] Set `MAGE_MODE=production`: verify toolbar is blocked regardless of config
- [ ] Verify `SearchClient::beforeQuery` no longer calls `dump()`
- [ ] Verify no performance regression from guard caching pattern

🤖 Generated with [Claude Code](https://claude.com/claude-code)