### PR TITLE
security: systematic XSS remediation across all templates

### DIFF
--- a/Block/Tab/Content/Request.php
+++ b/Block/Tab/Content/Request.php
@@ -20,11 +20,12 @@ class Request extends \ADM\QuickDevBar\Block\Tab\Panel
     public function formatValue($data)
     {
         if (is_array($data['value'])) {
-            return '<pre>' . print_r($data['value'], true) . '</pre>';
+            return '<pre>' . $this->escapeHtml(print_r($data['value'], true)) . '</pre>';
         } elseif (!empty($data['is_url'])) {
-            return '<a target="_blank" href="' . $data['value'] . '">' . $data['value'] . '</a>';
+            return '<a target="_blank" href="' . $this->escapeUrl($data['value']) . '">'
+                . $this->escapeHtml($data['value']) . '</a>';
         } else {
-            return $data['value'];
+            return $this->escapeHtml($data['value']);
         }
     }
 }

--- a/Block/Tab/Content/Sql.php
+++ b/Block/Tab/Content/Sql.php
@@ -90,10 +90,10 @@ class Sql extends \ADM\QuickDevBar\Block\Tab\Panel
 
     public function formatSql($sql)
     {
-        $htmlSql = preg_replace('/\b(SET|AS|ASC|COUNT|DESC|IN|LIKE|DISTINCT|INTO|VALUES|LIMIT)\b/', '<span class="sqlword">\\1</span>', $sql);
+        $escapedSql = $this->escapeHtml($sql);
+        $htmlSql = preg_replace('/\b(SET|AS|ASC|COUNT|DESC|IN|LIKE|DISTINCT|INTO|VALUES|LIMIT)\b/', '<span class="sqlword">\\1</span>', $escapedSql);
         $htmlSql = preg_replace('/\b(UNION ALL|DESCRIBE|SHOW|connect|begin|commit)\b/', '<br/><span class="sqlother">\\1</span>', $htmlSql);
         $htmlSql = preg_replace('/\b(UPDATE|SELECT|FROM|WHERE|LEFT JOIN|INNER JOIN|RIGHT JOIN|ORDER BY|GROUP BY|DELETE|INSERT)\b/', '<br/><span class="sqlmain">\\1</span>', $htmlSql);
-
         return preg_replace('/^<br\/>/', '', $htmlSql);
     }
 

--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -437,11 +437,14 @@ class Data extends \Magento\Framework\App\Helper\AbstractHelper
         }
 
         if($btLinkFormat = $this->getIdeRegex()) {
-            return sprintf('<span data-ide-file="'.$btLinkFormat.'">'.$btFormat.'</span>', BP, $relativeFile, $line);
+            return sprintf(
+                '<span data-ide-file="%s">%s</span>',
+                htmlspecialchars(sprintf($btLinkFormat, BP, $relativeFile, $line), ENT_QUOTES),
+                htmlspecialchars(sprintf($btFormat, BP, $relativeFile, $line), ENT_QUOTES)
+            );
         }
 
-        return sprintf($btFormat, BP, $relativeFile, $line);
-
+        return htmlspecialchars(sprintf($btFormat, BP, $relativeFile, $line), ENT_QUOTES);
     }
 
     /**

--- a/view/base/templates/tab/design/handles.phtml
+++ b/view/base/templates/tab/design/handles.phtml
@@ -7,7 +7,7 @@
     <th><?=  __('Handles'); ?></th>
     <td>
     <?php foreach ($block->getHandles() as $handle): ?>
-        <?=  $handle; ?></br>
+        <?= $block->escapeHtml($handle); ?></br>
     <?php endforeach;?>
     <br/>
     </td>

--- a/view/base/templates/tab/info/config.phtml
+++ b/view/base/templates/tab/info/config.phtml
@@ -17,8 +17,8 @@
     $i = 0;
     foreach ($block->getConfigValues() as $config): ?>
   <tr>
-    <td><?=  $config['path']; ?></td>
-    <td><?=  $block->escapeHtml($config['value']); ?></td>
+    <td><?= $block->escapeHtml($config['path']); ?></td>
+    <td><?= $block->escapeHtml($config['value']); ?></td>
   </tr>
         <?php $i++; ?>
     <?php endforeach ?>

--- a/view/base/templates/tab/info/request.phtml
+++ b/view/base/templates/tab/info/request.phtml
@@ -13,8 +13,8 @@
 <table class="qdb_table_2col">
 <?php foreach ($block->getRequestData() as $data):?>
     <tr>
-        <th><?=  $data['name'];?></th>
-        <td><?=  $block->formatValue($data);?>
+        <th><?= $block->escapeHtml($data['name']); ?></th>
+        <td><?= $block->formatValue($data); ?>
     </td>
 <?php endforeach;?>
 </table>

--- a/view/base/templates/tab/log.phtml
+++ b/view/base/templates/tab/log.phtml
@@ -23,7 +23,7 @@
         let target =  'content-' +  key ;
         let params = new URLSearchParams({isAjax:1,log_key:key});
         window.quickDevBar.qdbFetchPromise('quickdevbar/log/reset/?' + params.toString()).then(html => {
-            document.getElementById(target).innerHTML = html;
+            document.getElementById(target).textContent = html;
         });
     };
 
@@ -32,7 +32,7 @@
         let target =  'content-' +  key ;
         let params = new URLSearchParams({isAjax:1,log_key:key,tail:<?=  $block->getTailLines(); ?>});
         window.quickDevBar.qdbFetchPromise('quickdevbar/log/view/?' + params.toString()).then(html => {
-            document.getElementById(target).innerHTML = html;
+            document.getElementById(target).textContent = html;
         });
     };
 

--- a/view/base/templates/tab/profile/cache.phtml
+++ b/view/base/templates/tab/profile/cache.phtml
@@ -17,10 +17,10 @@
 <tbody>
     <?php foreach ($block->getCacheEvents() as $identifier=>$events): ?>
       <tr>
-          <td><?=  $identifier; ?></td>
-          <td><?=  $events['save']; ?></td>
-        <td><?=  $events['load']; ?></td>
-        <td><?=  $events['remove']; ?></td>
+          <td><?= $block->escapeHtml($identifier); ?></td>
+          <td><?= (int)$events['save']; ?></td>
+        <td><?= (int)$events['load']; ?></td>
+        <td><?= (int)$events['remove']; ?></td>
       </tr>
     <?php endforeach ?>
 </tbody>

--- a/view/base/templates/tab/profile/cache.phtml
+++ b/view/base/templates/tab/profile/cache.phtml
@@ -5,24 +5,24 @@
 //TODO: Add all cache type
 ?>
 <?php if ($block->getCacheEvents()):?>
-<table class="qdb_table striped filterable">
-<thead>
-<tr>
-    <th>Identifier</th>
-    <th>Save</th>
-    <th>Load</th>
-    <th>Remove</th>
-</tr>
-</thead>
-<tbody>
-    <?php foreach ($block->getCacheEvents() as $identifier=>$events): ?>
-      <tr>
-          <td><?= $block->escapeHtml($identifier); ?></td>
-          <td><?= (int)$events['save']; ?></td>
-        <td><?= (int)$events['load']; ?></td>
-        <td><?= (int)$events['remove']; ?></td>
-      </tr>
-    <?php endforeach ?>
-</tbody>
-</table>
+    <table class="qdb_table striped filterable">
+        <thead>
+            <tr>
+                <th>Identifier</th>
+                <th>Save</th>
+                <th>Load</th>
+                <th>Remove</th>
+            </tr>
+        </thead>
+        <tbody>
+            <?php foreach ($block->getCacheEvents() as $identifier => $events): ?>
+                <tr>
+                    <td><?= $block->escapeHtml($identifier); ?></td>
+                    <td><?= (int)$events['save']; ?></td>
+                    <td><?= (int)$events['load']; ?></td>
+                    <td><?= (int)$events['remove']; ?></td>
+                </tr>
+            <?php endforeach ?>
+        </tbody>
+    </table>
 <?php endif;?>

--- a/view/base/templates/tab/profile/event.phtml
+++ b/view/base/templates/tab/profile/event.phtml
@@ -16,9 +16,9 @@
 <tbody>
     <?php foreach ($block->getEvents() as $event): ?>
       <tr>
-        <td><?=  $event['event']; ?></td>
-        <td><?=  (!empty($event['args']) ? '<ul><li>'.implode('</li><li>', $event['args']).'</li></ul>' : ''); ?></td>
-        <td><?=  $event['nbr']; ?></td>
+        <td><?= $block->escapeHtml($event['event']); ?></td>
+        <td><?php if (!empty($event['args'])): ?><ul><?php foreach ($event['args'] as $arg): ?><li><?= $block->escapeHtml($arg) ?></li><?php endforeach; ?></ul><?php endif; ?></td>
+        <td><?= (int)$event['nbr']; ?></td>
       </tr>
     <?php endforeach ?>
 </tbody>

--- a/view/base/templates/tab/profile/observer.phtml
+++ b/view/base/templates/tab/profile/observer.phtml
@@ -19,10 +19,10 @@
     $i = 0;
     foreach ($block->getObservers() as $observer): ?>
   <tr>
-    <td><?=  $observer['event']; ?></td>
-    <td><?=  $observer['name']; ?></td>
-    <td><?=  $observer['call_number']; ?></td>
-    <td><?=  $block->htmlFormatClass($observer['instance']); ?></td>
+    <td><?= $block->escapeHtml($observer['event']); ?></td>
+    <td><?= $block->escapeHtml($observer['name']); ?></td>
+    <td><?= (int)$observer['call_number']; ?></td>
+    <td><?= $block->htmlFormatClass($observer['instance']); ?></td>
   </tr>
         <?php $i++; ?>
     <?php endforeach ?>

--- a/view/base/templates/tab/translation/plain.phtml
+++ b/view/base/templates/tab/translation/plain.phtml
@@ -15,8 +15,8 @@
         $i = 0;
         foreach ($block->getTranslations() as $original => $translation): ?>
             <tr>
-                <td><?=  $original; ?></td>
-                <td><?=  $translation; ?></td>
+                <td><?= $block->escapeHtml($original); ?></td>
+                <td><?= $block->escapeHtml($translation); ?></td>
             </tr>
             <?php $i++; ?>
         <?php endforeach ?>

--- a/view/base/templates/tabs.phtml
+++ b/view/base/templates/tabs.phtml
@@ -8,14 +8,14 @@
 >
     <ul class="ui-tabs-nav" data-tabs tabbis-options='{"collapsible":<?=  $block->getIsMainTab() ? 'true' : 'false' ?>}'>
         <?php foreach ($block->getTabBlocks() as $tabBlock): ?>
-            <li id="<?=  $tabBlock->getId() ?>" class="<?=  $tabBlock->getClass() ?>" data-ajax="<?=  $tabBlock->isAjax(false) ? $tabBlock->getTabUrl() : '';?>" >
+            <li id="<?= $block->escapeHtmlAttr($tabBlock->getId()) ?>" class="<?= $block->escapeHtmlAttr($tabBlock->getClass()) ?>" data-ajax="<?= $tabBlock->isAjax(false) ? $block->escapeUrl($tabBlock->getTabUrl()) : ''; ?>" >
                 <a href="#"  >
                     <?php if ($tabBlock->getTitleImage()):?>
-                        <img  class="qdb-img" src="<?=  $block->getViewFileUrl($tabBlock->getTitleImage()) ?>">
+                        <img  class="qdb-img" src="<?= $block->escapeUrl($block->getViewFileUrl($tabBlock->getTitleImage())) ?>">
                     <?php endif;?>
-                    <?=  $tabBlock->getTitle() ?>
+                    <?= $block->escapeHtml($tabBlock->getTitle()) ?>
                     <?php if ($tabBlock->getTitleBadge()):?>
-                        <span class="qdb-tab-badge"><?=  $tabBlock->getTitleBadge();?></span>
+                        <span class="qdb-tab-badge"><?= $block->escapeHtml($tabBlock->getTitleBadge()); ?></span>
                     <?php endif;?>
                 </a>
             </li>
@@ -24,7 +24,7 @@
     <div data-panes>
     <?php $tabIndice = 0; ?>
     <?php foreach ($block->getTabBlocks() as $tabBlock): ?>
-        <div id="<?=  $tabBlock->getId('panel-') ?>" class="qdb-panel">
+        <div id="<?= $block->escapeHtmlAttr($tabBlock->getId('panel-')) ?>" class="qdb-panel">
             <?=  ($tabBlock->isAjax(false)) ? $tabBlock->getHtmlLoader('big') : $tabBlock->toHtml(); ?>
         </div>
         <?php $tabIndice++; ?>

--- a/view/base/templates/tabs.phtml
+++ b/view/base/templates/tabs.phtml
@@ -2,7 +2,7 @@
 /** @var \ADM\QuickDevBar\Block\Tab\Wrapper $block */
 ?>
 
-<div class="qdb-container <?=  $block->getUiTabClass() ?>"
+<div class="qdb-container <?= $block->escapeHtmlAttr($block->getUiTabClass()) ?>"
  style="display: block;"
  "
 >

--- a/view/base/templates/toolbar.phtml
+++ b/view/base/templates/toolbar.phtml
@@ -97,6 +97,7 @@
                             this.qdbFetchPromise("quickdevbar/index/ajax").then(html => {
                                 const wrapperElem =  document.getElementById(this.options.etTabWrapper);
                                 wrapperElem.innerHTML = html;
+                                this.executeScriptElements(wrapperElem);
                             }).then(()=>{
                                 this.tabsObj= new tabbisClass(this.options.tabbisOptions);
                                 this.applyTabPlugin(document);
@@ -124,6 +125,25 @@
             },
             loadUserData:function(key) {
                 return localStorage.getItem(key);
+            },
+            /**
+             * @see https://stackoverflow.com/a/69190644
+             * @param containerElement
+             */
+            executeScriptElements:function (containerElement) {
+                const scriptElements = containerElement.querySelectorAll("script");
+
+                Array.from(scriptElements).forEach((scptElement) => {
+                    const clonedElement = document.createElement("script");
+
+                    Array.from(scptElement.attributes).forEach((attribute) => {
+                        clonedElement.setAttribute(attribute.name, attribute.value);
+                    });
+
+                    clonedElement.text = scptElement.text;
+
+                    scptElement.parentNode.replaceChild(clonedElement, scptElement);
+                });
             },
             qdbFetchPromise: function (routePath) {
                 const url = this.options.baseUrl + routePath;

--- a/view/base/templates/toolbar.phtml
+++ b/view/base/templates/toolbar.phtml
@@ -97,7 +97,6 @@
                             this.qdbFetchPromise("quickdevbar/index/ajax").then(html => {
                                 const wrapperElem =  document.getElementById(this.options.etTabWrapper);
                                 wrapperElem.innerHTML = html;
-                                this.executeScriptElements(wrapperElem);
                             }).then(()=>{
                                 this.tabsObj= new tabbisClass(this.options.tabbisOptions);
                                 this.applyTabPlugin(document);
@@ -125,28 +124,6 @@
             },
             loadUserData:function(key) {
                 return localStorage.getItem(key);
-            },
-            /**
-             * @see https://stackoverflow.com/a/69190644
-             * @param containerElement
-             */
-            executeScriptElements:function (containerElement) {
-
-
-                const scriptElements = containerElement.querySelectorAll("script");
-
-                Array.from(scriptElements).forEach((scptElement) => {
-                    const clonedElement = document.createElement("script");
-
-                    Array.from(scptElement.attributes).forEach((attribute) => {
-                        clonedElement.setAttribute(attribute.name, attribute.value);
-                    });
-
-                    clonedElement.text = scptElement.text;
-                    this.log(scptElement)
-                    // May cause a csp violation
-                    scptElement.parentNode.replaceChild(clonedElement, scptElement);
-                });
             },
             qdbFetchPromise: function (routePath) {
                 const url = this.options.baseUrl + routePath;


### PR DESCRIPTION
## Summary

- Escape all variable output in templates with `escapeHtml`/`escapeHtmlAttr`/`escapeUrl`
- Rewrite `formatSql()` to escape input before applying syntax highlighting
- Escape IDE link helper HTML output with `htmlspecialchars`
- Replace `innerHTML` with `textContent` in log viewer
- Remove `executeScriptElements()` which re-activated scripts from AJAX HTML

## Security Findings Addressed

| ID | Finding | Severity |
|---|---|---|
| H6 | formatSql() applies regex to raw SQL without escaping | High |
| H7 | Templates output variables without escapeHtml | High |
| H8 | executeScriptElements re-runs scripts from innerHTML | High |
| M5 | IDE link helper outputs unescaped file paths | Medium |

## Files Modified

- `Block/Tab/Content/Sql.php` — formatSql() escape-first
- `Block/Tab/Content/Request.php` — formatValue() escaping
- `Helper/Data.php` — getIDELinkForFile() htmlspecialchars
- 9 template files — escapeHtml/escapeHtmlAttr/escapeUrl applied
- `toolbar.phtml` — executeScriptElements removed
- `log.phtml` — innerHTML → textContent

## Test plan

- [ ] Verify SQL tab still highlights keywords with colored spans
- [ ] Verify event/observer/cache tabs render correctly with escaped output
- [ ] Verify log viewer displays log content as plain text
- [ ] Verify IDE links still work when IDE integration is configured
- [ ] Verify no raw HTML injection possible via crafted SQL or event names

🤖 Generated with [Claude Code](https://claude.com/claude-code)