### PR TITLE
perf: scope observers to frontend/adminhtml areas only

### DIFF
--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="layout_generate_blocks_after">
+        <observer name="qdb_layout_generate_blocks_after" instance="ADM\QuickDevBar\Observer\LayoutGenerateBlocksAfterObserver" />
+    </event>
+    <event name="controller_front_send_response_before">
+        <observer name="qdb_controller_front_send_response_before" instance="ADM\QuickDevBar\Observer\ControllerFrontSendResponseBeforeObserver" />
+    </event>
+    <event name="layout_load_before">
+        <observer name="qdb_custom_layout" instance="ADM\QuickDevBar\Observer\UpdateLayoutObserver" />
+    </event>
+    <event name="view_block_abstract_to_html_after">
+        <observer name="qdb_view_block_abstract_to_html_after" instance="ADM\QuickDevBar\Observer\CheckHtmlObserver" />
+    </event>
+</config>

--- a/etc/events.xml
+++ b/etc/events.xml
@@ -1,28 +1,3 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
-    <event name="layout_generate_blocks_after">
-        <observer name="qdb_layout_generate_blocks_after" instance="ADM\QuickDevBar\Observer\LayoutGenerateBlocksAfterObserver" />
-    </event>
-
-
-
-    <!--
-    TODO: remplacer par un plugin afterSend
-
-    <type name="Magento\Framework\App\Response\Http">
-            <plugin name="qdb_response_http_page_cache" type="ADM\QuickDevBar\Plugin\App\Response\HttpPlugin"/>
-        </type>
-     -->
-    <event name="controller_front_send_response_before">
-        <observer name="qdb_controller_front_send_response_before" instance="ADM\QuickDevBar\Observer\ControllerFrontSendResponseBeforeObserver" />
-    </event>
-
-    <event name="layout_load_before">
-        <observer name="qdb_custom_layout" instance="ADM\QuickDevBar\Observer\UpdateLayoutObserver" />
-    </event>
-
-    <event name="view_block_abstract_to_html_after">
-        <observer name="qdb_view_block_abstract_to_html_after" instance="ADM\QuickDevBar\Observer\CheckHtmlObserver" />
-    </event>
-
 </config>

--- a/etc/frontend/events.xml
+++ b/etc/frontend/events.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="layout_generate_blocks_after">
+        <observer name="qdb_layout_generate_blocks_after" instance="ADM\QuickDevBar\Observer\LayoutGenerateBlocksAfterObserver" />
+    </event>
+    <event name="controller_front_send_response_before">
+        <observer name="qdb_controller_front_send_response_before" instance="ADM\QuickDevBar\Observer\ControllerFrontSendResponseBeforeObserver" />
+    </event>
+    <event name="layout_load_before">
+        <observer name="qdb_custom_layout" instance="ADM\QuickDevBar\Observer\UpdateLayoutObserver" />
+    </event>
+    <event name="view_block_abstract_to_html_after">
+        <observer name="qdb_view_block_abstract_to_html_after" instance="ADM\QuickDevBar\Observer\CheckHtmlObserver" />
+    </event>
+</config>


### PR DESCRIPTION
## Summary

- Move all 4 observers from global `etc/events.xml` to area-specific `etc/frontend/events.xml` and `etc/adminhtml/events.xml`
- Observers no longer fire on REST API, GraphQL, CLI, or cron requests

## Security Findings Addressed

| ID | Finding | Severity |
|---|---|---|
| M6 | Global observers fire on API/CLI/cron unnecessarily | Medium |

## Test plan

- [ ] Verify toolbar still appears on frontend pages
- [ ] Verify toolbar still appears in admin panel
- [ ] Verify API requests (REST/GraphQL) no longer trigger QDB observers
- [ ] Verify CLI commands no longer trigger QDB observers

🤖 Generated with [Claude Code](https://claude.com/claude-code)