### PR TITLE
security+perf: gate SQL profiler on access check, fix object creation

### DIFF
--- a/Plugin/Zend/DbAdapter.php
+++ b/Plugin/Zend/DbAdapter.php
@@ -3,20 +3,20 @@
 namespace ADM\QuickDevBar\Plugin\Zend;
 
 use ADM\QuickDevBar\Helper\Cookie;
-use ADM\QuickDevBar\Helper\Data as QdbHelper;
+use ADM\QuickDevBar\Service\AccessChecker;
 use Zend_Db_Adapter_Abstract;
 
 class DbAdapter
 {
     private Cookie $cookieHelper;
-    private QdbHelper $qdbHelper;
+    private AccessChecker $accessChecker;
 
     public function __construct(
         Cookie $cookieHelper,
-        QdbHelper $qdbHelper
+        AccessChecker $accessChecker
     ) {
         $this->cookieHelper = $cookieHelper;
-        $this->qdbHelper = $qdbHelper;
+        $this->accessChecker = $accessChecker;
     }
 
     /**
@@ -26,8 +26,8 @@ class DbAdapter
      */
     public function beforeSetProfiler(Zend_Db_Adapter_Abstract $subject, $profiler): array
     {
-        if ($this->qdbHelper->isToolbarAccessAllowed()
-            && $this->cookieHelper->isProfilerEnabled()
+        if ($this->cookieHelper->isProfilerEnabled()
+            && $this->accessChecker->isToolbarAccessAllowed()
         ) {
             $profiler = [
                 'enabled' => 1,

--- a/Plugin/Zend/DbAdapter.php
+++ b/Plugin/Zend/DbAdapter.php
@@ -3,18 +3,21 @@
 namespace ADM\QuickDevBar\Plugin\Zend;
 
 use ADM\QuickDevBar\Helper\Cookie;
+use ADM\QuickDevBar\Helper\Data as QdbHelper;
 use Zend_Db_Adapter_Abstract;
 
 class DbAdapter
 {
     private Cookie $cookieHelper;
+    private QdbHelper $qdbHelper;
 
     public function __construct(
-        Cookie $cookieHelper
+        Cookie $cookieHelper,
+        QdbHelper $qdbHelper
     ) {
         $this->cookieHelper = $cookieHelper;
+        $this->qdbHelper = $qdbHelper;
     }
-
 
     /**
      * @param Zend_Db_Adapter_Abstract $subject
@@ -23,10 +26,12 @@ class DbAdapter
      */
     public function beforeSetProfiler(Zend_Db_Adapter_Abstract $subject, $profiler): array
     {
-        if($this->cookieHelper->isProfilerEnabled()) {
+        if ($this->qdbHelper->isToolbarAccessAllowed()
+            && $this->cookieHelper->isProfilerEnabled()
+        ) {
             $profiler = [
-                'enabled'=>1,
-                'class'  => \ADM\QuickDevBar\Profiler\Db::class
+                'enabled' => 1,
+                'class'   => \ADM\QuickDevBar\Profiler\Db::class,
             ];
         }
 

--- a/Profiler/Db.php
+++ b/Profiler/Db.php
@@ -21,7 +21,7 @@ class Db extends \Zend_Db_Profiler
         if(empty($this->cookieHelper)) {
             //Mea culpa, mea maxima culpa
             $objectManager = ObjectManager::getInstance();
-            $this->cookieHelper = $objectManager->create(\ADM\QuickDevBar\Helper\Cookie::class);
+            $this->cookieHelper = $objectManager->get(\ADM\QuickDevBar\Helper\Cookie::class);
         }
 
         return $this->cookieHelper->isProfilerBacktraceEnabled();


### PR DESCRIPTION
## Summary

- Require `isToolbarAccessAllowed()` before enabling SQL profiler (H4)
- Change `ObjectManager::create()` to `get()` in `Profiler/Db` to avoid constructing ~300 Cookie helper instances per page load (M10)

## Security Findings Addressed

| ID | Finding | Severity |
|---|---|---|
| H4 | SQL profiler activatable by any visitor with the right cookie | High |
| M10 | Per-query object creation wastes ~300 allocations per page | Medium |

## Test plan

- [ ] Verify SQL profiler activates when toolbar is allowed AND profiler cookie is set
- [ ] Verify SQL profiler does NOT activate when toolbar access is denied
- [ ] Verify profiler still records queries and backtraces correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)