### PR TITLE
Fix Symfony 7 conflicts

### DIFF
--- a/Console/Command/AbstractStatusToolbar.php
+++ b/Console/Command/AbstractStatusToolbar.php
@@ -92,7 +92,7 @@ abstract class AbstractStatusToolbar extends \Symfony\Component\Console\Command\
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
 
         $this->resourceConfig->saveConfig('dev/quickdevbar/enable', $this->status);

--- a/Console/Command/Database.php
+++ b/Console/Command/Database.php
@@ -65,7 +65,7 @@ class Database extends \Symfony\Component\Console\Command\Command
     /**
      * {@inheritdoc}
      */
-    protected function execute(InputInterface $input, OutputInterface $output)
+    protected function execute(InputInterface $input, OutputInterface $output): int
     {
 
         $connection = $this->resource->getConnection();


### PR DESCRIPTION
This fixes issues in the upcoming Magento 2.4.9 due to updated Symfony versions:

```
 PHP Fatal error:  Declaration of ADM\QuickDevBar\Console\Command\AbstractStatusToolbar::execute(Symfony\Component\Console\Input\InputInterface $input,
  Symfony\Component\Console\Output\OutputInterface $output) must be compatible with Symfony\Component\Console\Command\Command::execute(Symfony\Component\Console\Input\InputInterface
  $input, Symfony\Component\Console\Output\OutputInterface $output): int
```